### PR TITLE
Expand metadata for language detection

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -10,7 +10,7 @@
             "tags": "queries/tags.scm",
             "locals": "queries/locals.scm",
             "folds": "queries/folds.scm",
-            "injection-regex": "^(axs|axi|axb|lib)$"
+            "injection-regex": "^netlinx$"
         }
     ],
     "metadata": {

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -10,6 +10,8 @@
             "tags": "queries/tags.scm",
             "locals": "queries/locals.scm",
             "folds": "queries/folds.scm",
+            "first-line-regex": "^(PROGRAM|MODULE)_NAME\\s*=.*$",
+            "content-regex": "^DEFINE_(DEVICE|CONSTANT|TYPE|VARIABLE|START|EVENT|PROGRAM)$",
             "injection-regex": "^netlinx$"
         }
     ],

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -10,8 +10,8 @@
             "tags": "queries/tags.scm",
             "locals": "queries/locals.scm",
             "folds": "queries/folds.scm",
-            "first-line-regex": "^(PROGRAM|MODULE)_NAME\\s*=.*$",
-            "content-regex": "^DEFINE_(DEVICE|CONSTANT|TYPE|VARIABLE|START|EVENT|PROGRAM)$",
+            "first-line-regex": "(?i)^(program|module)_name\\s*=.*$",
+            "content-regex": "(?i)^define_(device|constant|type|variable|start|event|program)$",
             "injection-regex": "^netlinx$"
         }
     ],


### PR DESCRIPTION
## Description

Adds additional fields to the parser metdata to improve [language detection](https://tree-sitter.github.io/tree-sitter/cli/init.html#language-detection). In cases where a filename match is not possible this enables tree-sitter to better detect if this may be the appropriate parser to use.

This PR also sets `netlinx` as the language term used to detect injections. Previously, file extension were used, however this enables embeddings such as:

````md
<!-- example.md -->

This is some markdown showing a NetLinx code embedding:

```netlinx
define_function long answer(Universe input)
{
  return 42;
}
```
````
for better uniformity with other grammars.

## Type of Change

<!-- What type of change does your PR introduce? -->

- [ ] Bug fix (non-breaking change addressing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Grammar enhancement (improving parsing without changing functionality)
- [ ] Documentation update
- [ ] Test update

## Testing

<!-- Describe the testing you've done -->

- [ ] Added new tests that pass
- [ ] All tests pass
- [ ] Manually tested with example code:

## Documentation

<!-- If needed, have you updated the documentation? -->

- [ ] Updated README.md
- [ ] Updated other documentation files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Summary by Sourcery

Enhance metadata and language detection capabilities for tree-sitter parsers by adding more flexible detection mechanisms and supporting NetLinx language embeddings

New Features:
- Expanded parser metadata to improve language detection
- Added 'netlinx' as a language term for detecting code injections