### PR TITLE
fix: remove invalid `grammars.*.folds` key

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
     "grammars": [
         {
             "name": "netlinx",
@@ -9,7 +10,6 @@
             "highlights": ["queries/highlights.scm"],
             "tags": "queries/tags.scm",
             "locals": "queries/locals.scm",
-            "folds": "queries/folds.scm",
             "first-line-regex": "(?i)^(program|module)_name\\s*=.*$",
             "content-regex": "(?i)^define_(device|constant|type|variable|start|event|program)$",
             "injection-regex": "^netlinx$"


### PR DESCRIPTION
This key doesn't exist in the upstream schema, see <https://github.com/tree-sitter/tree-sitter/blob/v0.26.5/docs/src/assets/schemas/config.schema.json>. Should it?

## Summary by Sourcery

Bug Fixes:
- Drop the invalid `grammars.*.folds` entry from the Tree-sitter config to match the upstream schema.